### PR TITLE
Add Scalding to T02TransformTest.scala

### DIFF
--- a/src/test/scala/com/spotify/bdrc/testing/T02TransformTest.scala
+++ b/src/test/scala/com/spotify/bdrc/testing/T02TransformTest.scala
@@ -51,7 +51,7 @@ object WordCount2 {
  * - Does not cover argument parsing and IO handling
  * - May disrupt pipeline logic flow if overused
  *
- * Supported in: Scio, Spark
+ * Supported in: Scalding, Scio, Spark
  *
  * Recommendation:
  * Complex pipelines can be broken into logical blocks and tested using this approach. Individual


### PR DESCRIPTION
Add Scalding to the list of supported frameworks

You can write tests against `TypedPipe` as you would do for `RDD` or `SCollection`, `collect()` can be implemented as:

```scala
  def collect[A](typedPipe: TypedPipe[A]): Vector[A] = {
    val conf = Config.empty
    val mode = Local(strictSources = true)

    typedPipe.toIterableExecution.waitFor(conf, mode).get.toVector
  }
```